### PR TITLE
Avoid directly accessing window.localStorage

### DIFF
--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -1088,7 +1088,8 @@ PostHogLib.prototype.set_config = function (config) {
         if (this['persistence']) {
             this['persistence'].update_config(this['config'])
         }
-        if (localStorage && localStorage.getItem('ph_debug') === 'true') {
+        
+        if (localStore.is_supported() && localStore.get('ph_debug') === 'true') {
             this['config']['debug'] = true
         }
         Config.DEBUG = Config.DEBUG || this.get_config('debug')


### PR DESCRIPTION
## Changes

The `set_config`-function is directly accessing the `localStorage` instead of using the `localStore` this gives issues when PostHog client is used in restricted environments such as `iframe`-elements which can't access `localStorage`

## Checklist
- [X] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
