### PR TITLE
fix: call reloadFeatureFlags on featureFlags

### DIFF
--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -916,7 +916,7 @@ PostHogLib.prototype.reset = function (reset_device_id) {
     )
 
     // trigger onFeatureFlags callback
-    this.persistence.receivedFeatureFlags()
+    this.featureFlags.reloadFeatureFlags()
 }
 
 /**


### PR DESCRIPTION
## Changes

Call the `reloadFeatureFlags` on the `featureFlags`-object instead of `persistence`

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
